### PR TITLE
Improving existing implementation of deepwalk

### DIFF
--- a/deepwalk/__main__.py
+++ b/deepwalk/__main__.py
@@ -148,7 +148,7 @@ def main():
   parser.add_argument('--number-walks', default=10, type=int,
                       help='Number of random walks to start at each node')
 
-  parser.add_argument('--output', required=False,
+  parser.add_argument('--output', required=False, default='./node_embeddings.model',
                       help='Output representation file')
 
   parser.add_argument('--representation-size', default=64, type=int,

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ test_requirements = [
 
 setup(
     name='deepwalk',
-    version='1.0.3',
+    version='1.0.4',
     description='DeepWalk online learning of social representations.',
     long_description=readme + '\n\n' + history,
     author='Bryan Perozzi',


### PR DESCRIPTION
I found issues while running this library on my graph. So thought of improving the current implementation a little bit. It comprises of the following. 
1. In case of an **orphan node** in the **Neo4j** graph, the embedding vector of that node is never built, which is correct as the node will never appear in the walk. But while dumping the embeddings to Neo4j, we try to get embedding vector for this node, which will raise an exception. The solution is to first check if the node-id is in the **model vocabulary**. 
2. If selecting the **--format** as **neo**, I added the following 2 options as mandatory parameter, first to pass a **neo4j connection URL** (in case the graph is hosted on different machine or uses non-default username and password or port configurations), second to ask if one want to save the node-embeddings to the graph.
